### PR TITLE
Ignore a preceding /host_mnt in the Hyper-V mount path

### DIFF
--- a/docker_volume_watcher/container_monitor.py
+++ b/docker_volume_watcher/container_monitor.py
@@ -24,7 +24,7 @@ def docker_bind_to_windows_path(path):
         str:  Converts Hyper-V mount path to Windows path (e.g. /C/some-path -> C:/some-path).
 
     """
-    expr = re.compile('^/([a-zA-Z])/(.*)$')
+    expr = re.compile('^(?:/host_mnt)?/([a-zA-Z])/(.*)$')
     match = re.match(expr, path)
     if not match:
         return None


### PR DESCRIPTION
I'm not sure if this was a change in my environment or a change in Docker, but I had to make this change recently in order to keep it working. Without this, I'd get errors such as

```
WARNING:root:Bind of container website_web_run_13 was skipped since it has invalid source path /host_mnt/c/Users/...
WARNING:root:Bind of container website_web_1 was skipped since it has invalid source path /host_mnt/c/Users/...
WARNING:root:No mounts match container name pattern * and host directory pattern *
```