### PR TITLE
Set Docker dependency to version >=3.0.0 and handle new exec_run response

### DIFF
--- a/docker_volume_watcher/container_notifier.py
+++ b/docker_volume_watcher/container_notifier.py
@@ -11,7 +11,12 @@ from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 
 class NonZeroExitError(RuntimeError):
-    def __init__(self,exit_code):
+    """
+    A non-zero exit code error from the command execution in docker.
+    """
+
+    def __init__(self, exit_code):
+        super(NonZeroExitError, self).__init__()
         self.exit_code = exit_code
 
 class ContainerNotifier(object):
@@ -65,7 +70,7 @@ class ContainerNotifier(object):
             absolute_path)
         try:
             permissions = self.container.exec_run(
-                ['stat', '-c', '%a', absolute_path], privileged=True)   
+                ['stat', '-c', '%a', absolute_path], privileged=True)
             if permissions.exit_code != 0:
                 raise NonZeroExitError(permissions.exit_code)
             permissions = permissions.output.decode('utf-8').strip()
@@ -80,10 +85,10 @@ class ContainerNotifier(object):
                 'Failed to notify container %s about change in %s',
                 self.container.name,
                 absolute_path, exc_info=True)
-        except NonZeroExitError as e:
+        except NonZeroExitError as exception:
             logging.error(
                 'Exec run returned non-zero exit code: %s',
-                e.exit_code)
+                exception.exit_code)
 
     def stop(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 watchdog>=0.8.3
-docker>=2.2.1
+docker>=3.0.0
 pypiwin32>=219

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='docker-windows-volume-watcher',
       url='http://github.com/merofeev/docker-windows-volume-watcher',
       install_requires=[
         'watchdog>=0.8.3',
-        'docker>=2.2.1',
+        'docker>=3.0.0',
         'pypiwin32>=219; platform_system=="Windows"'
         ],
       license='MIT',


### PR DESCRIPTION
* Ugrades Docker dependecy to version >= 3.0.0
* Parses output of `exec_run` to use `output`
* Catches error if exit is non-zero

Fixes #8 and #9.