### PR TITLE
fix: parsing multiple filepath formats

### DIFF
--- a/docker_volume_watcher/container_monitor.py
+++ b/docker_volume_watcher/container_monitor.py
@@ -24,7 +24,15 @@ def docker_bind_to_windows_path(path):
         str:  Converts Hyper-V mount path to Windows path (e.g. /C/some-path -> C:/some-path).
 
     """
-    expr = re.compile('^(?:/host_mnt)?/([a-zA-Z])/(.*)$')
+    if re.match('^[a-zA-Z]\:(/|\\\\).*$', path):
+        # matches <drive>:\any or <drive>:\any
+        # eg: C:/some/thi/ng , C:\some\thi\ng
+        return path
+    
+    # one regex to rule them all
+    # matches:: any/<drive>/any
+    # eg: /mnt/c/any/thing , /host/c/any/thi/ng , /host_mnt/c/any
+    expr = re.compile("^(?:.*)?/([a-zA-Z])/(.*)$")
     match = re.match(expr, path)
     if not match:
         return None


### PR DESCRIPTION
Parse windows style and *nix style host filepath properly
#### Examples, of what's accepted:
- windows filepath
  - eg: C:\some\thing
  - eg: C:/some/thing
- *nix style filepath
  - eg: /mnt/C/some/thing
  - eg: /host_mnt/C/some/thing
  - eg: /run/desktop/mnt/host/C/some/thing

Logic:
- First check if valid Windows Filepath
- Next, parse *nix style filepath
  - convert to windows filepath

Created a PR based on my [comment in another PR for this](https://github.com/merofeev/docker-windows-volume-watcher/pull/20#issuecomment-1454700278)